### PR TITLE
Better solution for loading first (without postinst)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,10 @@ before-package::
 	ldid -S -M -Ksigncert.p12 $(THEOS_STAGING_DIR)/usr/lib/FJHooker.dylib
 	chmod 755 $(THEOS_STAGING_DIR)/Applications/FlyJB.app/FlyJB
 
+internal-stage::
+	mv "$(THEOS_STAGING_DIR)/Library/MobileSubstrate/DynamicLibraries/FlyJBX.dylib" "$(THEOS_STAGING_DIR)/Library/MobileSubstrate/DynamicLibraries/ FlyJBX.dylib"
+	mv "$(THEOS_STAGING_DIR)/Library/MobileSubstrate/DynamicLibraries/FlyJBX.plist" "$(THEOS_STAGING_DIR)/Library/MobileSubstrate/DynamicLibraries/ FlyJBX.plist"
+
 after-install::
 	install.exec "killall -9 SpringBoard"
 SUBPROJECTS += FlyJBXPrefs FJHooker

--- a/layout/DEBIAN/postinst
+++ b/layout/DEBIAN/postinst
@@ -5,20 +5,5 @@ if [[ -f "/private/var/mobile/Library/Preferences/kr.xsf1re.flyjb_crashfix.plist
 else
 	echo "[FlyJB X] Couldn't find kr.xsf1re.flyjb_crashfix.plist"
 fi
-if [[ -f "/Library/MobileSubstrate/DynamicLibraries/ FlyJBX.dylib" ]]; then
-	rm -f "/Library/MobileSubstrate/DynamicLibraries/ FlyJBX.dylib" &> /dev/null
-else
-	echo "[FlyJB X] Couldn't find renamed FlyJBX.dylib"
-fi
-if [[ -f "/Library/MobileSubstrate/DynamicLibraries/ FlyJBX.plist" ]]; then
-	rm -f "/Library/MobileSubstrate/DynamicLibraries/ FlyJBX.plist" &> /dev/null
-else
-	echo "[FlyJB X] Couldn't find renamed FlyJBX.plist"
-fi
-
-
-echo "[FlyJB X] Renaming to load before other tweaks..."
-mv "/Library/MobileSubstrate/DynamicLibraries/FlyJBX.dylib" "/Library/MobileSubstrate/DynamicLibraries/ FlyJBX.dylib" &> /dev/null
-mv "/Library/MobileSubstrate/DynamicLibraries/FlyJBX.plist" "/Library/MobileSubstrate/DynamicLibraries/ FlyJBX.plist" &> /dev/null
 
 echo "[FlyJB X] Done."

--- a/layout/DEBIAN/prerm
+++ b/layout/DEBIAN/prerm
@@ -5,27 +5,6 @@ if [[ -f "/private/var/mobile/Library/Preferences/kr.xsf1re.flyjb_crashfix.plist
 else
     echo "[FlyJB X] Couldn't find kr.xsf1re.flyjb_crashfix.plist"
 fi
-if [[ -f "/Library/MobileSubstrate/DynamicLibraries/FlyJBX.dylib" ]]; then
-	rm -f "/Library/MobileSubstrate/DynamicLibraries/FlyJBX.dylib" &> /dev/null
-else
-	echo "[FlyJB X] Couldn't find FlyJBX.dylib"
-fi
-if [[ -f "/Library/MobileSubstrate/DynamicLibraries/FlyJBX.plist" ]]; then
-	rm -f "/Library/MobileSubstrate/DynamicLibraries/FlyJBX.plist" &> /dev/null
-else
-	echo "[FlyJB X] Couldn't find FlyJBX.plist"
-fi
-echo "[FlyJB X] Renaming files to remove..."
-if [[ -f "/Library/MobileSubstrate/DynamicLibraries/ FlyJBX.dylib" ]]; then
-	mv "/Library/MobileSubstrate/DynamicLibraries/ FlyJBX.dylib" "/Library/MobileSubstrate/DynamicLibraries/FlyJBX.dylib" &> /dev/null
-else
-	echo "[FlyJB X] Couldn't find renamed FlyJBX.dylib"
-fi
-if [[ -f "/Library/MobileSubstrate/DynamicLibraries/ FlyJBX.plist" ]]; then
-	mv "/Library/MobileSubstrate/DynamicLibraries/ FlyJBX.plist" "/Library/MobileSubstrate/DynamicLibraries/FlyJBX.plist" &> /dev/null
-else
-	echo "[FlyJB X] Couldn't find renamed FlyJBX.plist"
-fi
 if [[ -f "/private/var/mobile/Library/Preferences/FJMemory" ]]; then
 	rm -f "/private/var/mobile/Library/Preferences/FJMemory" &> /dev/null
 else


### PR DESCRIPTION
Removes the need to rename the dylib in the postinst / prerm scripts by renaming the dylib before packaging, it's also more dpkg friendly this way.